### PR TITLE
Add an index.js package export for backwards compatibilty

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
   "main": "index.cjs",
   "module": "index.js",
   "exports": {
-    "import": "./index.js",
-    "require": "./index.cjs"
+    ".": {
+      "import": "./index.js",
+      "require": "./index.cjs"
+    },
+    "./index.js": "./index.js"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",


### PR DESCRIPTION
This change will allow modules to remain mostly backwards compatible after applying it, by still letting users deep-import from index.js.
