### PR TITLE
Fix package.json field name: tags -> keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fluture-project",
   "version": "0.0.0",
   "description": "Hopefully something related to Fluture",
-  "tags": [
+  "keywords": [
     "fluture"
   ],
   "type": "module",


### PR DESCRIPTION
See https://www.npmjs.com/search?q=fluture%2Dnode

`fluture-node` uses `tags`, because it follows `fluture-template`. They don't show up in the npm search results.
`fluture` uses `keywords`, and it does show up.
