### PR TITLE
Update distribution method for better browser support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,15 +15,18 @@ This pull request adds everything the project needs to be at its first release.
 - [ ] Name the project:
     - Change `repo-name` in `.config` and ensure the tests pass.
     - Change the header of the documentation in `index.js`.
-    - Change the module name in `rollup.config.js`.
+    - Replace occurrences of `fluture-project` in `index.js`.
+    - Change the value of `output.name` in `rollup.config.js`.
+    - Replace occurrences of `flutureProject` in `index.js` to follow the value of `output.name` from the previous step.
 
 - [ ] Describe the project:
     - Change `description` in `package.json`.
     - Update the GitHub repo description.
-    - Add the description to the documentation in `index.js`.
+    - Update the description to the documentation in `index.js`.
     - Add additional `tags` in `package.json`.
 
 - [ ] If this is a node-only module, remove browser support:
+    - Remove browser usage instructions from the README.
     - Change `umd` to `cjs` in `rollup.config.js` and remove `output.name`.
     - Change `eslint-es3` to `eslint-es6` in `.eslintrc.json`.
     - Change `shared-node-browser` to `node` in `.eslintrc.json`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /coverage/
-/index.cjs
+/dist/*
 /node_modules/
+
+!/dist/package.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,10 @@
 When adding a dependency, first consider whether to add it as
 a *regular* or as a *peer* dependency.
 
-Make sure to update `rollup.config.js` after installing a new dependency.
+Make sure to update `rollup.config.js` and the usage instructions in `index.js`
+after installing a new dependency . Peer dependencies need to be included in the
+`npm install` example, and all dependencies need to be mentioned in the UMD
+scripting instructions.
 
 ### Regular Dependency
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,44 @@
 1. Checkout `master` and make sure it's up to date with the remote
 1. Run `npm run release <level>`, where `<level>` can be any of: 'major',
    'minor', 'patch', 'premajor', 'preminor', 'prepatch', or 'prerelease'.
+
+## Dependency Management
+
+When adding a dependency, first consider whether to add it as
+a *regular* or as a *peer* dependency.
+
+Make sure to update `rollup.config.js` after installing a new dependency.
+
+### Regular Dependency
+
+Choose a regular dependency when its internal structure is hidden from the
+end-user. For example, if you depend on Fluture internally, but never expose
+Future instances from any of your public facing functions.
+
+The version of a regular dependency should be pinned at the major version
+number. For example `^1.1.0` would allow any versions greater than `1.1.0` and
+smaller than `2.0.0`.
+
+### Peer Dependency
+
+Choose a peer dependency when any of its internal structure is exposed to the
+end-user. For example, if you depend on Fluture and return Future instances
+from public-facing functions, then you should add Fluture as a peer dependency.
+
+The version range of peer dependencies should be as wide as you can make it.
+For example, if you code works with Fluture version 1 as well as version 2, then
+your dependency range should be `>=1.0.0 <3.0.0`. Then whenever a new compatible
+version of Fluture is released, you bump the upper bound to include it. If you
+have to make a breaking change to support the new version of the peer dependency
+then you reset the lower bound.
+
+### Package Lock
+
+We don't use a package lock file, because this is a library, not a tool. The
+reproducible builds provided by a package lock would benefit the developers of
+the library, but not its users. When users install this library, the
+`package.json` file is used to resolve the versions of sub-depdencies. This
+means that even if the developers of this library would have a working
+reproducible build, the library might be installing broken dependencies for its
+users. The trade-off we're making here is that we lose build reproducibility in
+development, but we gain an earlier insight in when a dependency is broken.

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/index.js
+++ b/index.js
@@ -1,1 +1,36 @@
 //. # Fluture Project
+//.
+//. Hopefully something related to Fluture.
+//.
+//. ## Usage
+//.
+//. ### Node
+//.
+//. ```console
+//. $ npm install --save fluture-project
+//. ```
+//.
+//. On Node 12 and up, this module can be loaded directly with `import` or
+//. `require`. On Node versions below 12, `require` or the [esm][]-loader can
+//. be used.
+//.
+//. ### Deno and Modern Browsers
+//.
+//. You can load the EcmaScript module from various content delivery networks:
+//.
+//. - [Skypack](https://cdn.skypack.dev/fluture-project@0.0.0)
+//. - [JSPM](https://jspm.dev/fluture-project@0.0.0)
+//. - [jsDelivr](https://cdn.jsdelivr.net/npm/fluture-project@0.0.0/+esm)
+//.
+//. ### Old Browsers and Code Pens
+//.
+//. There's a [UMD][] file included in the NPM package, also available via
+//. jsDelivr: https://cdn.jsdelivr.net/npm/fluture-project@0.0.0/dist/umd.js
+//.
+//. This file adds `flutureProject` to the global scope, or use CommonJS/AMD
+//. when available.
+
+export default void 0;
+
+//. [esm]: https://github.com/standard-things/esm
+//. [UMD]: https://github.com/umdjs/umd

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "fluture"
   ],
   "type": "module",
-  "main": "index.cjs",
+  "main": "./dist/umd.js",
   "module": "index.js",
   "exports": {
     ".": {
       "import": "./index.js",
-      "require": "./index.cjs"
+      "require": "./dist/umd.js"
     },
     "./index.js": "./index.js"
   },
@@ -28,7 +28,7 @@
     "url": "git://github.com/fluture-js/fluture-project.git"
   },
   "files": [
-    "/index.cjs",
+    "/dist",
     "/index.js",
     "/LICENSE",
     "/package.json",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,18 @@
+import pkg from './package.json';
+
+const dependencyNames = Array.prototype.concat.call (
+  Object.keys (pkg.dependencies),
+  Object.keys (pkg.peerDependencies)
+);
+
 export default {
   input: 'index.js',
+  external: dependencyNames,
   output: {
     format: 'umd',
-    file: 'index.cjs',
+    file: 'dist/umd.js',
     name: 'flutureProject',
-    interop: false
+    exports: 'named',
+    globals: {}
   }
 };


### PR DESCRIPTION
See fluture-js/fluture-sanctuary-types#73

The main problem is the `.cjs` extensions, which confused content
delivery networks. Simply changing the extension to `.js` won't work,
because that'd confuse Node 12 and up.

So besides changing the extension, the file has also been moved into a
sub-directory containing a package.json file that tells newer Node
versions that the files here are CommonJS (without the need for a file
extension).

This PR also adds documentation for the different ways that the
module can now be obtained, and documentation for contributors
about managing dependencies.